### PR TITLE
Withdraw Rikito Taniguchi's signature

### DIFF
--- a/index.md
+++ b/index.md
@@ -307,7 +307,6 @@ Additional support:
 * Richard Ashworth
 * Richard Costine
 * Richard Dallaway
-* Rikito Taniguchi
 * Rishabh Agarwal
 * Rishad Sewnarain
 * Rose Toomey


### PR DESCRIPTION
I support the goal of providing safe space for the community.

However, I regret blindly believing the legitimacy of one side's claims and expressing support for excluding a party from the community in this manner, without having the necessary information to make a correct judgment.

Therefore, please withdraw my signature from this open letter.